### PR TITLE
Fetch smaller batch from the queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "manageiq-messaging", '~> 0.1.0'
+gem "manageiq-messaging", '~> 0.1.2'
 
 gem "inventory_refresh",          :git => "https://github.com/ManageIQ/inventory_refresh",          :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"

--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -21,10 +21,7 @@ module TopologicalInventory
 
         logger.info("Topological Inventory Persister started...")
 
-        # Wait for messages to be processed
-        # TODO(lsmola) do: client.subscribe_messages(queue_opts.merge(:max_bytes => 500000))
-        # Once this is merged and released: https://github.com/ManageIQ/manageiq-messaging/pull/35
-        client.subscribe_messages(queue_opts) do |messages|
+        client.subscribe_messages(queue_opts.merge(:max_bytes => 500000)) do |messages|
           messages.each { |msg| process_message(client, msg) }
         end
       ensure


### PR DESCRIPTION
By default, the ruby-kafka was fetching up to 10MB of data,
that could cause spikes in memory, when the queue is full.
We'll fetch only 0.5MB now.