### PR TITLE
Fix database name in database.dev.yml

### DIFF
--- a/config/database.dev.yml
+++ b/config/database.dev.yml
@@ -10,13 +10,13 @@ default: &default
 
 development:
   <<: *default
-  database: topological_inventory_persister_development
+  database: topological_inventory_development
   min_messages: notice
 
 test:
   <<: *default
-  database: topological_inventory_persister_test
+  database: topological_inventory_test
 
 production:
   <<: *default
-  database: topological_inventory_persister_production
+  database: topological_inventory_production


### PR DESCRIPTION
we are using `database.dev.yml`s as templates for `database.yml` so let's use same name of DB
as is used in other `topology-` repositories for example [here](https://github.com/ManageIQ/topological_inventory-api/blob/master/config/database.dev.yml#L13)