### PR TITLE
Stream graph refresh output to kafka

### DIFF
--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -69,6 +69,7 @@ module TopologicalInventory
           :protocol   => :Kafka,
           :client_ref => "persister-worker",
           :group_ref  => "persister-worker",
+          :encoding   => "json",
         }
       end
     end

--- a/lib/topological_inventory/persister/workflow.rb
+++ b/lib/topological_inventory/persister/workflow.rb
@@ -130,7 +130,7 @@ module TopologicalInventory
         messaging_client.publish_message(
           :service => "platform.topological-inventory.persister-output",
           :message => "event",
-          :payload => message.to_json, # TODO(lsmola) Need to encode to json, since miq-messaging fails encoding this to YAML
+          :payload => message
         )
       end
 

--- a/lib/topological_inventory/persister/workflow.rb
+++ b/lib/topological_inventory/persister/workflow.rb
@@ -104,12 +104,34 @@ module TopologicalInventory
         upsert_refresh_state_records(:status => :started, :refresh_state_status => :started)
 
         persist!
+        send_changes_to_queue!
 
         upsert_refresh_state_records(:status => :finished)
       rescue StandardError => e
         upsert_refresh_state_records(:status => :error, :error_message => e.message.truncate(150))
 
         raise(e)
+      end
+
+      def send_changes_to_queue!
+        message = {
+          :external_tenant => manager.tenant.external_tenant,
+          :source          => manager.uid
+        }
+
+        message[:payload] = persister.inventory_collections.select { |x| x.name }.index_by(&:name).transform_values! do |x|
+          hash = {}
+          hash[:created] = x.created_records unless x.created_records.empty?
+          hash[:updated] = x.updated_records unless x.updated_records.empty?
+          hash[:deleted] = x.deleted_records unless x.deleted_records.empty?
+          hash.empty? ? nil : hash
+        end.compact
+
+        messaging_client.publish_message(
+          :service => "platform.topological-inventory.persister-output",
+          :message => "event",
+          :payload => message.to_json, # TODO(lsmola) Need to encode to json, since miq-messaging fails encoding this to YAML
+        )
       end
 
       # Sweeps inactive records based on :last_seen_at attribute

--- a/spec/persister/collections_spec.rb
+++ b/spec/persister/collections_spec.rb
@@ -30,6 +30,9 @@ describe TopologicalInventory::Persister::Worker do
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
+
+      # There should be 1 publish call writing to persister-output queue
+      expect(client).to receive(:publish_message).exactly(1).times
     end
 
     it "refreshes flavors" do

--- a/spec/persister/mark_and_sweep_spec.rb
+++ b/spec/persister/mark_and_sweep_spec.rb
@@ -33,6 +33,8 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "automatically fills :last_seen_at timestamp for refreshed entities and archives them in last step" do
+      expect(client).to receive(:publish_message).exactly(2).times
+
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
       time_after  = Time.now.utc + 2.hours
@@ -88,6 +90,8 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "sweeps only inventory_collections listed in persister's :sweep_scope" do
+      expect(client).to receive(:publish_message).exactly(2).times
+
       time_now = Time.now.utc
       time_before = Time.now.utc - 20.seconds
       time_after  = Time.now.utc + 2.hours
@@ -143,6 +147,8 @@ describe TopologicalInventory::Persister::Worker do
     end
 
     it "checks partial update failure will error out the whole refresh_state" do
+      expect(client).to receive(:publish_message).exactly(1).times
+
       allow(TopologicalInventory::Persister).to receive(:logger).and_return(::InventoryRefresh::NullLogger.new)
 
       cg1 = ContainerGroup.create!(:source => source, :tenant => tenant, :source_ref => "a40e2927-77b8-487e-92bb-63f32989b015")

--- a/spec/persister/worker_spec.rb
+++ b/spec/persister/worker_spec.rb
@@ -28,6 +28,7 @@ describe TopologicalInventory::Persister::Worker do
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
+      allow(client).to receive(:publish_message)
       allow(client).to receive(:subscribe_messages).and_yield(messages)
 
       described_class.new.run


### PR DESCRIPTION
Each message will contain primary keys of created, deleted or
changed entities for the batch persistor persisted.