### PR TITLE
Use the entrypoint script to set env vars and run_persister in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR $WORKDIR
 
 COPY . $WORKDIR
 COPY docker-assets/entrypoint /usr/bin
+COPY docker-assets/run_persister /usr/bin
 
 RUN source /opt/rh/rh-postgresql10/enable && \
     echo "gem: --no-document" > ~/.gemrc && \
@@ -33,3 +34,4 @@ RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR
 
 ENTRYPOINT ["entrypoint"]
+CMD ["run_persister"]

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,31 +1,12 @@
 #!/bin/bash
 
-function write_encryption_key() {
-  echo "== Writing encryption key =="
-  cat > $WORKDIR/v2_key << KEY
----
-:algorithm: aes-256-cbc
-:key: ${ENCRYPTION_KEY}
-KEY
+function urlescape() {
+  PAYLOAD="$1" ruby -rcgi -e "puts CGI.escape(ENV['PAYLOAD'])"
 }
 
-function check_svc_status() {
-  local SVC_NAME=$1 SVC_PORT=$2
+safeuser=$(urlescape ${DATABASE_USER})
+safepass=$(urlescape ${DATABASE_PASSWORD})
 
-  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
+export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/topological_inventory_production?encoding=utf8&pool=5&wait_timeout=5"
 
-  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
-
-  while true; do
-    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
-    sleep 5
-  done
-  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
-}
-
-write_encryption_key
-
-# Wait for postgres to be ready
-check_svc_status $DATABASE_HOST $DATABASE_PORT
-
-bin/topological_inventory-persister
+exec ${@}

--- a/docker-assets/run_persister
+++ b/docker-assets/run_persister
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function write_encryption_key() {
+  echo "== Writing encryption key =="
+  cat > $WORKDIR/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${ENCRYPTION_KEY}
+KEY
+}
+
+function check_svc_status() {
+  local SVC_NAME=$1 SVC_PORT=$2
+
+  [[ $# -lt 2 ]] && echo "Error something seems wrong, we need at least two parameters to check service status" && exit 1
+
+  echo "== Checking ${SVC_NAME}:$SVC_PORT status =="
+
+  while true; do
+    ncat ${SVC_NAME} ${SVC_PORT} < /dev/null && break
+    sleep 5
+  done
+  echo "${SVC_NAME}:${SVC_PORT} - accepting connections"
+}
+
+write_encryption_key
+
+# Wait for postgres to be ready
+check_svc_status $DATABASE_HOST $DATABASE_PORT
+
+bin/topological_inventory-persister


### PR DESCRIPTION
This allows us to share environment variables in a sane way between
the CMD and users who may get a separate console session into a
running container.

This also provides a place for us to put the definition of
DATABASE_URL as it won't live in the database secret in production

This should be merged with ManageIQ/topological_inventory-deploy#45