### PR TITLE
Add metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,7 @@ RUN source /opt/rh/rh-postgresql10/enable && \
 RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR
 
+EXPOSE 9394
+
 ENTRYPOINT ["entrypoint"]
 CMD ["run_persister"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "manageiq-loggers",   "~> 0.1.0"
-gem "manageiq-messaging", "~> 0.1.2"
+gem "manageiq-loggers",    "~> 0.1.0"
+gem "manageiq-messaging",  "~> 0.1.2"
+gem "prometheus_exporter", "~> 0.4.5"
 
 gem "inventory_refresh",          :git => "https://github.com/ManageIQ/inventory_refresh",          :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"

--- a/lib/topological_inventory/persister/metrics.rb
+++ b/lib/topological_inventory/persister/metrics.rb
@@ -1,0 +1,24 @@
+require "benchmark"
+require "prometheus_exporter"
+require "prometheus_exporter/client"
+
+module TopologicalInventory
+  module Persister
+    class Metrics
+      def initialize
+        @client = PrometheusExporter::Client.default
+        @process_counter = @client.register(:counter, "messages_total", "total number of messages processed")
+        @process_timer = @client.register(:histogram, "message_process_seconds", "time it took to process messages")
+      end
+
+      def record_process(success = true)
+        @process_counter.observe(1, :result => success ? "success" : "error")
+      end
+
+      def record_process_timing
+        time = Benchmark.realtime { yield }
+        @process_timer.observe(time)
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/persister/metrics.rb
+++ b/lib/topological_inventory/persister/metrics.rb
@@ -1,14 +1,15 @@
 require "benchmark"
 require "prometheus_exporter"
+require "prometheus_exporter/server"
 require "prometheus_exporter/client"
+require 'prometheus_exporter/instrumentation'
 
 module TopologicalInventory
   module Persister
     class Metrics
-      def initialize
-        @client = PrometheusExporter::Client.default
-        @process_counter = @client.register(:counter, "messages_total", "total number of messages processed")
-        @process_timer = @client.register(:histogram, "message_process_seconds", "time it took to process messages")
+      def initialize(port = 9394)
+        configure_server(port)
+        configure_metrics
       end
 
       def record_process(success = true)
@@ -18,6 +19,30 @@ module TopologicalInventory
       def record_process_timing
         time = Benchmark.realtime { yield }
         @process_timer.observe(time)
+      end
+
+      def stop_server
+        @server.stop
+      end
+
+      private
+
+      def configure_server(port)
+        @server = PrometheusExporter::Server::WebServer.new(:port => port)
+        @server.start
+
+        PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(:collector => @server.collector)
+      end
+
+      def configure_metrics
+        PrometheusExporter::Instrumentation::Process.start
+
+        PrometheusExporter::Metric::Base.default_prefix = "topological_inventory_persister_"
+
+        @process_counter = PrometheusExporter::Metric::Counter.new("messages_total", "total number of messages processed")
+        @process_timer = PrometheusExporter::Metric::Histogram.new("message_process_seconds", "time it took to process messages")
+        @server.collector.register_metric(@process_counter)
+        @server.collector.register_metric(@process_timer)
       end
     end
   end

--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -33,6 +33,7 @@ module TopologicalInventory
         logger.error(e.backtrace.join("\n"))
       ensure
         client&.close
+        metrics&.stop_server
       end
 
       private

--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -2,6 +2,7 @@ require "inventory_refresh"
 require "manageiq-messaging"
 require "topological_inventory/persister/logging"
 require "topological_inventory/persister/workflow"
+require "topological_inventory/persister/metrics"
 require "topological_inventory/schema"
 
 module TopologicalInventory
@@ -13,6 +14,7 @@ module TopologicalInventory
         self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
 
         InventoryRefresh.logger = logger
+        self.metrics = TopologicalInventory::Persister::Metrics.new
       end
 
       def run
@@ -22,7 +24,9 @@ module TopologicalInventory
         logger.info("Topological Inventory Persister started...")
 
         client.subscribe_messages(queue_opts.merge(:max_bytes => 500000)) do |messages|
-          messages.each { |msg| process_message(client, msg) }
+          messages.each do |msg|
+            metrics.record_process_timing { process_message(client, msg) }
+          end
         end
       rescue => e
         logger.error(e.message)
@@ -33,14 +37,17 @@ module TopologicalInventory
 
       private
 
-      attr_accessor :messaging_client_opts, :client
+      attr_accessor :messaging_client_opts, :client, :metrics
 
       def process_message(client, msg)
         TopologicalInventory::Persister::Workflow.new(load_persister(msg.payload), client, msg.payload).execute!
       rescue => e
+        metrics.record_process(false)
         logger.error(e.message)
         logger.error(e.backtrace.join("\n"))
         nil
+      else
+        metrics.record_process
       end
 
       def load_persister(payload)

--- a/spec/persister/metrics_spec.rb
+++ b/spec/persister/metrics_spec.rb
@@ -1,0 +1,30 @@
+require "topological_inventory/persister/metrics"
+require "net/http"
+
+describe TopologicalInventory::Persister::Metrics do
+  subject! { described_class.new(9394) }
+  after    { subject.stop_server }
+
+  it "exposes metrics" do
+    subject.record_process
+    subject.record_process
+    subject.record_process false
+    subject.record_process_timing { }
+
+    metrics = get_metrics
+    expect(metrics["topological_inventory_persister_messages_total{result=\"success\"}"]).to eq("2")
+    expect(metrics["topological_inventory_persister_messages_total{result=\"error\"}"]).to eq("1")
+    expect(metrics["topological_inventory_persister_message_process_seconds_bucket{le=\"+Inf\"}"]).to eq("1")
+  end
+
+  def get_metrics
+    metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
+      e.blank? || e.start_with?("#")
+    end
+
+    metrics.each_with_object({}) do |m, hash|
+      k, v = m.split
+      hash[k] = v
+    end
+  end
+end


### PR DESCRIPTION
I'm running the prometheus exporter service in the same process here.

This gives us information about the local ruby process and also allows us to run the metrics server in test, dev, and production in the same way.

@Ladas let me know what you think about the metrics I'm collecting in this first pass. Feel free to add more in a follow-up, but I want to know if you think these will be useful.