### PR TITLE
subscribe_messages has serious issues

### DIFF
--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -23,10 +23,8 @@ module TopologicalInventory
 
         logger.info("Topological Inventory Persister started...")
 
-        client.subscribe_messages(queue_opts.merge(:max_bytes => 500000)) do |messages|
-          messages.each do |msg|
-            metrics.record_process_timing { process_message(client, msg) }
-          end
+        client.subscribe_topic(queue_opts) do |msg|
+          metrics.record_process_timing { process_message(client, msg) }
         end
       rescue => e
         logger.error(e.message)
@@ -68,7 +66,8 @@ module TopologicalInventory
 
       def queue_opts
         {
-          :service => "platform.topological-inventory.persister",
+          :service     => "platform.topological-inventory.persister",
+          :persist_ref => "persister_worker"
         }
       end
 

--- a/spec/persister/refresh_worker_helper.rb
+++ b/spec/persister/refresh_worker_helper.rb
@@ -2,9 +2,9 @@ module TestInventory
   module RefreshWorkerHelper
     def refresh(client, path)
       inventory = JSON.parse(File.read(test_inventory_dir.join(*path)))
-      messages = [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil, client)]
+      message = ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil, client)
 
-      allow(client).to receive(:subscribe_messages).and_yield(messages)
+      allow(client).to receive(:subscribe_topic).and_yield(message)
 
       described_class.new.run
       source.reload

--- a/spec/persister/worker_spec.rb
+++ b/spec/persister/worker_spec.rb
@@ -23,13 +23,13 @@ describe TopologicalInventory::Persister::Worker do
   end
 
   context "#run" do
-    let(:messages) { [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil, client)] }
+    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil, client) }
 
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
       allow(client).to receive(:publish_message)
-      allow(client).to receive(:subscribe_messages).and_yield(messages)
+      allow(client).to receive(:subscribe_topic).and_yield(message)
 
       described_class.new.run
       source.reload


### PR DESCRIPTION
subscribe_messages uses ruby-kafka each_batch, while
subscribe_topic uses each_message. There is something wrong,
probably with offset commit, in the each_batch. At scale of
200k - 1.2M records tested, almost 1 third of messages was being
dropped or skipped.

Switching to each_message for now, until we figure out what is
causing the each_batch issues. The implementation of each_message
seems to work without problems.