### PR TITLE
Metrics port as an argument

### DIFF
--- a/bin/topological_inventory-persister
+++ b/bin/topological_inventory-persister
@@ -7,8 +7,8 @@ require "topological_inventory/core/ar_helper"
 
 opts = {
   :host => ENV["QUEUE_HOST"] || "localhost",
-  :port => ENV["QUEUE_PORT"] || 9092,
-  :metrics_port => ENV["METRICS_PORT"] || 9394 # 0 disables metrics
+  :port => (ENV["QUEUE_PORT"] || 9092).to_i,
+  :metrics_port => (ENV["METRICS_PORT"] || 9394).to_i # 0 disables metrics
 }
 
 TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")

--- a/bin/topological_inventory-persister
+++ b/bin/topological_inventory-persister
@@ -5,11 +5,15 @@ require "bundler/setup"
 require "topological_inventory/persister/worker"
 require "topological_inventory/core/ar_helper"
 
-queue_host = ENV["QUEUE_HOST"] || "localhost"
-queue_port = ENV["QUEUE_PORT"] || 9092
+opts = {
+  :host => ENV["QUEUE_HOST"] || "localhost",
+  :port => ENV["QUEUE_PORT"] || 9092,
+  :metrics_port => ENV["METRICS_PORT"] || 9394 # 0 disables metrics
+}
 
 TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("../config/database.yml")
 TopologicalInventory::Core::ArHelper.load_environment!
 
-persister_worker = TopologicalInventory::Persister::Worker.new(:host => queue_host, :port => queue_port)
+
+persister_worker = TopologicalInventory::Persister::Worker.new(opts)
 persister_worker.run

--- a/lib/topological_inventory/persister/metrics.rb
+++ b/lib/topological_inventory/persister/metrics.rb
@@ -8,21 +8,23 @@ module TopologicalInventory
   module Persister
     class Metrics
       def initialize(port = 9394)
+        return if port == 0
+
         configure_server(port)
         configure_metrics
       end
 
       def record_process(success = true)
-        @process_counter.observe(1, :result => success ? "success" : "error")
+        @process_counter&.observe(1, :result => success ? "success" : "error")
       end
 
       def record_process_timing
         time = Benchmark.realtime { yield }
-        @process_timer.observe(time)
+        @process_timer&.observe(time)
       end
 
       def stop_server
-        @server.stop
+        @server&.stop
       end
 
       private

--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -15,7 +15,7 @@ module TopologicalInventory
         self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
 
         InventoryRefresh.logger = logger
-        self.metrics = TopologicalInventory::Persister::Metrics.new(opts[:metrics_port].to_i)
+        self.metrics = TopologicalInventory::Persister::Metrics.new(opts[:metrics_port])
       end
 
       def run

--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -10,11 +10,12 @@ module TopologicalInventory
     class Worker
       include Logging
 
-      def initialize(messaging_client_opts = {})
+      def initialize(opts = {})
+        messaging_client_opts = opts.select { |k, _| %i[host port].include?(k) }
         self.messaging_client_opts = default_messaging_opts.merge(messaging_client_opts)
 
         InventoryRefresh.logger = logger
-        self.metrics = TopologicalInventory::Persister::Metrics.new
+        self.metrics = TopologicalInventory::Persister::Metrics.new(opts[:metrics_port].to_i)
       end
 
       def run

--- a/spec/persister/refresh_worker_helper.rb
+++ b/spec/persister/refresh_worker_helper.rb
@@ -6,7 +6,7 @@ module TestInventory
 
       allow(client).to receive(:subscribe_topic).and_yield(message)
 
-      described_class.new.run
+      described_class.new(:metrics_port => 9394).run
       source.reload
     end
   end

--- a/spec/persister/worker_spec.rb
+++ b/spec/persister/worker_spec.rb
@@ -26,7 +26,7 @@ describe TopologicalInventory::Persister::Worker do
       allow(client).to receive(:publish_message)
       allow(client).to receive(:subscribe_topic).and_yield(message)
 
-      described_class.new.run
+      described_class.new(:metrics_port => 9394).run
       source.reload
     end
 


### PR DESCRIPTION
Metrics port is configurable by  `ENV["METRICS_PORT"]`. Defaults to 9394

Port 0 disables metrics