### PR TITLE
Added source_type to schema

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -320,6 +320,9 @@ class OpenapiGenerator
         :source                  => {
           :type => "string"
         },
+        :source_type             => {
+          :type => "string"
+        },
         :refresh_state_uuid      => {
           :type   => "string",
           :format => "uuid"


### PR DESCRIPTION
source_type name is needed for creating Source with first payload from CFME (through **insights-upload** svc -> **topological-inventory-sync/inventory-upload-worker**)