### PR TITLE
Cleanup exception handling

### DIFF
--- a/lib/topological_inventory/persister/exception.rb
+++ b/lib/topological_inventory/persister/exception.rb
@@ -1,0 +1,9 @@
+module TopologicalInventory
+  module Persister
+    module Exception
+      class Error < StandardError; end
+      class SourceUidNotFound < Error; end
+      class InvalidSchemaName < Error; end
+    end
+  end
+end


### PR DESCRIPTION
Log exception as one record so it's more readable in kibana
and log uknown source_uid as warn, since that can happen
when we delete a source and we still have items in a queue.