### PR TITLE
Openapi array must have items definition

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -340,7 +340,10 @@ class OpenapiGenerator
               :type => "object"
             },
             {
-              :type => "array"
+              :type  => "array",
+              :items => {
+                :type => "string"
+              }
             }
           ]
 


### PR DESCRIPTION
OpenAPI Generators 4.1+ cannot generate client by JSON generated by `openapi:generate` rake task. 
It fails with validation error: `-attribute components.schemas.Inventory.items is missing`

Regarding to OpenAPI specification:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
**items MUST be present if the type is array**.

---

- ingress-api: https://github.com/ManageIQ/topological_inventory-ingress_api/pull/69
- ingress-api-client: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/57
